### PR TITLE
Initial alert-triage implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install ruff
+        run: pip install ruff
+
+      - name: Ruff check
+        run: ruff check .
+
+      - name: Ruff format check
+        run: ruff format --check .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: meta
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.version }}
+            ghcr.io/${{ github.repository }}:latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+dist/
+build/
+.env
+*.env
+!*.example.env
+.venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY pyproject.toml README.md ./
+COPY alert_triage/ alert_triage/
+
+RUN pip install --no-cache-dir .
+
+EXPOSE 8099
+
+CMD ["uvicorn", "alert_triage.app:app", "--host", "0.0.0.0", "--port", "8099"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Tyler Wolf
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # alert-triage
 
+[![CI](https://github.com/tylerwolf/alert-triage/actions/workflows/ci.yml/badge.svg)](https://github.com/tylerwolf/alert-triage/actions/workflows/ci.yml)
+[![Release](https://github.com/tylerwolf/alert-triage/actions/workflows/release.yml/badge.svg)](https://github.com/tylerwolf/alert-triage/actions/workflows/release.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
+
 AI-powered alert diagnosis for Docker Compose stacks. Receives Alertmanager webhooks, investigates using Claude tool-calling (Loki logs, Prometheus metrics, Docker status), and posts diagnoses to Discord.
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -1,1 +1,113 @@
 # alert-triage
+
+AI-powered alert diagnosis for Docker Compose stacks. Receives Alertmanager webhooks, investigates using Claude tool-calling (Loki logs, Prometheus metrics, Docker status), and posts diagnoses to Discord.
+
+## Quick Start
+
+1. Create an env file with your API keys:
+
+```bash
+# alert-triage.env
+ANTHROPIC_API_KEY=sk-ant-...
+DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/...
+```
+
+2. Add to your monitoring stack's `docker-compose.yml`:
+
+```yaml
+services:
+  alert-triage:
+    image: ghcr.io/tylerwolf/alert-triage:0.1.0
+    container_name: alert-triage
+    restart: unless-stopped
+    env_file: alert-triage.env
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - alert_triage_data:/data
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8099/health')"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+volumes:
+  alert_triage_data:
+```
+
+3. Point Alertmanager at it:
+
+```yaml
+# alertmanager.yml
+receivers:
+  - name: alert-triage
+    webhook_configs:
+      - url: http://alert-triage:8099/webhook
+        send_resolved: false
+```
+
+That's it. Alerts fire, investigations run, diagnoses land in Discord.
+
+## System Prompt
+
+Out of the box, alert-triage uses a generic investigation prompt. For better results, describe your environment in a markdown file and mount it:
+
+```yaml
+environment:
+  - ALERT_TRIAGE_SYSTEM_PROMPT_FILE=/config/system-prompt.md
+volumes:
+  - ./my-system-prompt.md:/config/system-prompt.md:ro
+```
+
+The file should describe your services, network layout, and alert types. See [`system-prompt.example.md`](system-prompt.example.md) for a template.
+
+The generic base prompt (investigation methodology, output format) is always included — your file is appended to it.
+
+## Configuration
+
+All configuration is via environment variables. Variables prefixed with `ALERT_TRIAGE_` are specific to this project; `ANTHROPIC_API_KEY` and `DISCORD_WEBHOOK_URL` use their standard names.
+
+| Variable | Default | Description |
+|---|---|---|
+| `ANTHROPIC_API_KEY` | *(required)* | Anthropic API key |
+| `DISCORD_WEBHOOK_URL` | `None` | Discord webhook URL (omit to disable notifications) |
+| `ALERT_TRIAGE_MODEL` | `claude-sonnet-4-6` | Claude model to use |
+| `ALERT_TRIAGE_LOKI_URL` | `http://loki:3100` | Loki base URL |
+| `ALERT_TRIAGE_PROMETHEUS_URL` | `http://prometheus:9090` | Prometheus base URL |
+| `ALERT_TRIAGE_ALERTMANAGER_URL` | `http://alertmanager:9093` | Alertmanager base URL |
+| `ALERT_TRIAGE_DOCKER_SOCKET` | `/var/run/docker.sock` | Docker socket path |
+| `ALERT_TRIAGE_INCIDENTS_DIR` | `/data/incidents` | Directory for incident JSON files |
+| `ALERT_TRIAGE_SYSTEM_PROMPT_FILE` | `None` | Path to environment description markdown |
+| `ALERT_TRIAGE_DEDUP_WINDOW` | `1800` | Seconds to suppress duplicate alert sets |
+| `ALERT_TRIAGE_COALESCE_WINDOW` | `45` | Seconds to buffer alerts before investigating |
+| `ALERT_TRIAGE_MAX_CONCURRENT` | `3` | Max concurrent investigations |
+| `ALERT_TRIAGE_MAX_ITERATIONS` | `10` | Max tool-calling loop iterations per investigation |
+| `ALERT_TRIAGE_MAX_TOKENS` | `1024` | Max response tokens per Claude call |
+| `ALERT_TRIAGE_STARTUP_RECONCILE` | `true` | Check for firing alerts on startup |
+| `ALERT_TRIAGE_RECONCILE_DELAY` | `30` | Seconds to wait before startup reconciliation |
+| `ALERT_TRIAGE_PORT` | `8099` | Server port |
+
+## How It Works
+
+1. **Alertmanager** sends a webhook when alerts fire
+2. **Coalescing** buffers alerts for 45 seconds to group related alerts into one investigation
+3. **Dedup** skips alert sets already investigated in the last 30 minutes
+4. **Claude** receives the alert details and uses four tools to investigate:
+   - `query_loki` — search container logs via LogQL
+   - `query_prometheus` — query metrics via PromQL
+   - `get_docker_containers` — list container status via Docker API
+   - `get_alert_details` — get current alerts from Alertmanager
+5. **Diagnosis** is posted to Discord and saved as a JSON incident file
+6. **Startup reconciliation** checks Alertmanager for alerts that fired while the service was down
+
+## API
+
+| Endpoint | Method | Description |
+|---|---|---|
+| `/webhook` | POST | Alertmanager webhook receiver |
+| `/health` | GET | Health check |
+| `/incidents` | GET | List recent incidents (query: `?limit=20`) |
+| `/incidents/{id}` | GET | Get incident by ID |
+
+## License
+
+MIT

--- a/alert_triage/__init__.py
+++ b/alert_triage/__init__.py
@@ -1,0 +1,3 @@
+"""Alert Triage — AI-powered alert diagnosis for Docker Compose stacks."""
+
+__version__ = "0.1.0"

--- a/alert_triage/app.py
+++ b/alert_triage/app.py
@@ -1,0 +1,215 @@
+"""FastAPI application — webhook routes, coalescing, dedup, startup reconciliation."""
+
+import asyncio
+import logging
+import time
+import uuid
+
+import httpx
+from fastapi import FastAPI, Query, Request
+from fastapi.responses import JSONResponse
+
+from .config import Settings, build_system_prompt
+from .incidents import IncidentStore
+from .investigation import investigate
+from .notifications import DiscordNotifier, NullNotifier
+
+app = FastAPI(title="Alert Triage")
+log = logging.getLogger("alert-triage")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+settings = Settings()
+system_prompt = build_system_prompt(settings)
+incident_store = IncidentStore(settings.incidents_dir)
+
+if settings.discord_webhook_url:
+    notifier = DiscordNotifier(settings.discord_webhook_url)
+else:
+    notifier = NullNotifier()
+
+# Deduplication: frozenset of (alertname, instance) -> last investigation timestamp
+_recent: dict[frozenset, float] = {}
+
+# Concurrency cap
+_semaphore = asyncio.Semaphore(settings.max_concurrent)
+
+# Coalescing: buffer all alerts arriving in a window into one investigation
+_coalesce: dict | None = None
+_coalesce_lock = asyncio.Lock()
+
+
+def _alert_fingerprint(alerts: list[dict]) -> frozenset:
+    return frozenset(
+        (
+            a.get("labels", {}).get("alertname", ""),
+            a.get("labels", {}).get("instance", ""),
+        )
+        for a in alerts
+    )
+
+
+async def _flush_coalesce() -> None:
+    global _coalesce
+    await asyncio.sleep(settings.coalesce_window)
+
+    async with _coalesce_lock:
+        if _coalesce is None:
+            return
+        alerts = _coalesce["alerts"]
+        _coalesce = None
+
+    fp = _alert_fingerprint(alerts)
+    _recent[fp] = time.time()
+
+    now = time.time()
+    expired = [k for k, v in _recent.items() if now - v > settings.dedup_window]
+    for k in expired:
+        del _recent[k]
+
+    incident_id = str(uuid.uuid4())[:8]
+    alert_desc = ", ".join(
+        sorted({a.get("labels", {}).get("alertname", "?") for a in alerts})
+    )
+    log.info(
+        "Flushing coalesced buffer: %d alerts [%s] -> investigation %s",
+        len(alerts),
+        alert_desc,
+        incident_id,
+    )
+
+    async with _semaphore:
+        await investigate(
+            {"alerts": alerts},
+            incident_id,
+            settings,
+            system_prompt,
+            notifier,
+            incident_store,
+        )
+
+
+@app.on_event("startup")
+async def startup_reconcile() -> None:
+    if not settings.startup_reconcile:
+        return
+
+    async def _reconcile() -> None:
+        await asyncio.sleep(settings.reconcile_delay)
+        log.info("Startup reconciliation: checking Alertmanager for firing alerts")
+        try:
+            async with httpx.AsyncClient() as http:
+                resp = await http.get(
+                    f"{settings.alertmanager_url}/api/v2/alerts",
+                    timeout=10.0,
+                )
+                resp.raise_for_status()
+                alerts = resp.json()
+        except Exception as e:
+            log.warning("Startup reconciliation failed to reach Alertmanager: %s", e)
+            return
+
+        active = [
+            a
+            for a in alerts
+            if a.get("status", {}).get("state") == "active"
+            and not a.get("status", {}).get("silencedBy")
+        ]
+
+        if not active:
+            log.info("Startup reconciliation: no active non-silenced alerts")
+            return
+
+        alertnames = sorted({a.get("labels", {}).get("alertname", "?") for a in active})
+        log.info(
+            "Startup reconciliation: found %d active alert(s) [%s], investigating",
+            len(active),
+            ", ".join(alertnames),
+        )
+        incident_id = str(uuid.uuid4())[:8]
+        async with _semaphore:
+            await investigate(
+                {"alerts": active},
+                incident_id,
+                settings,
+                system_prompt,
+                notifier,
+                incident_store,
+            )
+
+    asyncio.create_task(_reconcile())
+
+
+@app.post("/webhook")
+async def webhook(request: Request) -> JSONResponse:
+    global _coalesce
+    payload = await request.json()
+
+    if payload.get("status") != "firing":
+        return JSONResponse({"status": "ignored", "reason": "not firing"})
+
+    incoming_alerts = payload.get("alerts", [])
+    if not incoming_alerts:
+        return JSONResponse({"status": "ignored", "reason": "no alerts"})
+
+    fp = _alert_fingerprint(incoming_alerts)
+    now = time.time()
+    if fp in _recent and (now - _recent[fp]) < settings.dedup_window:
+        log.info("Dedup: skipping (investigated %.0fs ago)", now - _recent[fp])
+        return JSONResponse({"status": "deduped"})
+
+    async with _coalesce_lock:
+        if _coalesce is None:
+            _coalesce = {
+                "alerts": list(incoming_alerts),
+                "seen": {
+                    (
+                        a.get("labels", {}).get("alertname", ""),
+                        a.get("labels", {}).get("instance", ""),
+                    )
+                    for a in incoming_alerts
+                },
+            }
+            _coalesce["task"] = asyncio.create_task(_flush_coalesce())
+            log.info(
+                "Coalesce: buffered %d alert(s), window open for %ds",
+                len(incoming_alerts),
+                settings.coalesce_window,
+            )
+            return JSONResponse({"status": "buffered"})
+        else:
+            added = 0
+            for a in incoming_alerts:
+                key = (
+                    a.get("labels", {}).get("alertname", ""),
+                    a.get("labels", {}).get("instance", ""),
+                )
+                if key not in _coalesce["seen"]:
+                    _coalesce["alerts"].append(a)
+                    _coalesce["seen"].add(key)
+                    added += 1
+            log.info(
+                "Coalesce: merged %d new alert(s) into buffer (total: %d)",
+                added,
+                len(_coalesce["alerts"]),
+            )
+            return JSONResponse({"status": "coalesced"})
+
+
+@app.get("/health")
+async def health() -> JSONResponse:
+    return JSONResponse({"status": "ok"})
+
+
+@app.get("/incidents/{incident_id}")
+async def get_incident(incident_id: str) -> JSONResponse:
+    data = incident_store.get(incident_id)
+    if data is None:
+        return JSONResponse({"error": "Incident not found"}, status_code=404)
+    return JSONResponse(data)
+
+
+@app.get("/incidents")
+async def list_incidents(
+    limit: int = Query(default=20, ge=1, le=100),
+) -> JSONResponse:
+    return JSONResponse(incident_store.list_recent(limit))

--- a/alert_triage/config.py
+++ b/alert_triage/config.py
@@ -1,0 +1,79 @@
+"""Configuration via environment variables with sensible defaults."""
+
+from pathlib import Path
+
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    model_config = {"env_prefix": "ALERT_TRIAGE_"}
+
+    # Required (no prefix — standard names)
+    anthropic_api_key: str = Field(alias="ANTHROPIC_API_KEY")
+    discord_webhook_url: str | None = Field(default=None, alias="DISCORD_WEBHOOK_URL")
+
+    # Model & API
+    model: str = "claude-sonnet-4-6"
+    max_tokens: int = 1024
+    max_iterations: int = 10
+
+    # Service URLs
+    loki_url: str = "http://loki:3100"
+    prometheus_url: str = "http://prometheus:9090"
+    alertmanager_url: str = "http://alertmanager:9093"
+    docker_socket: str = "/var/run/docker.sock"
+
+    # Storage
+    incidents_dir: Path = Path("/data/incidents")
+
+    # System prompt
+    system_prompt_file: Path | None = None
+
+    # Timing
+    dedup_window: int = 1800  # seconds
+    coalesce_window: int = 45  # seconds
+    max_concurrent: int = 3
+
+    # Startup reconciliation
+    startup_reconcile: bool = True
+    reconcile_delay: int = 30  # seconds
+
+    # Server
+    port: int = 8099
+
+
+BASE_SYSTEM_PROMPT = """\
+You are an AI diagnostician for a Docker Compose infrastructure stack. Your job is to \
+investigate firing Prometheus alerts by querying available data sources, then produce a \
+concise diagnosis with suggested remediation.
+
+## Investigation Approach
+1. Understand the alert: what fired, severity, duration
+2. Gather evidence: query relevant metrics, logs, and container status
+3. Correlate: look for related issues across services
+4. Diagnose: identify root cause or most likely explanation
+5. Suggest: provide actionable remediation steps
+
+## Guidelines
+- Make 2-5 tool calls per investigation (more if needed for complex issues)
+- For service-down alerts: always check container status + recent logs for that service
+- For resource alerts (CPU/memory): query container-level metrics to find top consumers
+- For mount/storage alerts: check if mount metrics exist, look for filesystem errors in logs
+- Use Loki for container logs (LogQL), Prometheus for metrics (PromQL)
+
+## Output Format
+Provide your analysis as:
+- **Confidence**: high / medium / low
+- **Diagnosis**: 3-5 bullet points summarizing what you found
+- **Suggested Actions**: concrete remediation steps the operator should take
+"""
+
+
+def build_system_prompt(settings: Settings) -> str:
+    """Build the full system prompt from base + optional user environment file."""
+    prompt = BASE_SYSTEM_PROMPT
+    if settings.system_prompt_file and settings.system_prompt_file.exists():
+        user_prompt = settings.system_prompt_file.read_text().strip()
+        prompt = prompt + "\n\n" + user_prompt
+    return prompt

--- a/alert_triage/incidents.py
+++ b/alert_triage/incidents.py
@@ -1,0 +1,67 @@
+"""Incident storage and retrieval."""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+class IncidentStore:
+    def __init__(self, incidents_dir: Path) -> None:
+        self.dir = incidents_dir
+        self.dir.mkdir(parents=True, exist_ok=True)
+
+    def save(
+        self,
+        incident_id: str,
+        alert_payload: dict,
+        tool_transcript: list[dict],
+        diagnosis: str,
+        model: str,
+        tokens: dict,
+        duration_s: float,
+    ) -> Path:
+        alerts = alert_payload.get("alerts", [])
+        alertnames = sorted(
+            {a.get("labels", {}).get("alertname", "unknown") for a in alerts}
+        )
+        alertname = "+".join(alertnames) if alertnames else "unknown"
+        ts = datetime.now(timezone.utc).strftime("%Y-%m-%d_%H-%M-%S")
+        incident_file = self.dir / f"{ts}_{incident_id}_{alertname}.json"
+        incident_data = {
+            "incident_id": incident_id,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "alert_payload": alert_payload,
+            "tool_transcript": tool_transcript,
+            "diagnosis": diagnosis,
+            "model": model,
+            "tokens": tokens,
+            "duration_s": round(duration_s, 2),
+        }
+        incident_file.write_text(json.dumps(incident_data, indent=2, default=str))
+        return incident_file
+
+    def get(self, incident_id: str) -> dict | None:
+        matches = list(self.dir.glob(f"*_{incident_id}_*.json"))
+        if not matches:
+            return None
+        return json.loads(matches[0].read_text())
+
+    def list_recent(self, limit: int = 20) -> list[dict]:
+        files = sorted(self.dir.glob("*.json"), reverse=True)[:limit]
+        incidents = []
+        for f in files:
+            data = json.loads(f.read_text())
+            alertnames = [
+                a.get("labels", {}).get("alertname", "unknown")
+                for a in data.get("alert_payload", {}).get("alerts", [])
+            ]
+            incidents.append(
+                {
+                    "incident_id": data.get("incident_id"),
+                    "timestamp": data.get("timestamp"),
+                    "alerts": sorted(set(alertnames)),
+                    "duration_s": data.get("duration_s"),
+                    "tokens": data.get("tokens"),
+                }
+            )
+        return incidents

--- a/alert_triage/investigation.py
+++ b/alert_triage/investigation.py
@@ -1,0 +1,122 @@
+"""Claude-powered alert investigation loop."""
+
+import logging
+import time
+
+import anthropic
+import httpx
+
+from .config import Settings
+from .incidents import IncidentStore
+from .notifications import Notifier
+from .tools import TOOLS, execute_tool
+
+log = logging.getLogger("alert-triage")
+
+
+async def investigate(
+    alert_payload: dict,
+    incident_id: str,
+    settings: Settings,
+    system_prompt: str,
+    notifier: Notifier,
+    incident_store: IncidentStore,
+) -> None:
+    """Run an AI-powered investigation for a set of firing alerts."""
+    start_time = time.monotonic()
+    tool_transcript: list[dict] = []
+    alerts = alert_payload.get("alerts", [])
+    alert_summary = []
+    for a in alerts:
+        labels = a.get("labels", {})
+        annotations = a.get("annotations", {})
+        alert_summary.append(
+            f"- **{labels.get('alertname', 'unknown')}** ({labels.get('severity', '?')}): "
+            f"{annotations.get('summary', 'no summary')} — "
+            f"{annotations.get('description', 'no description')}"
+        )
+
+    user_message = (
+        "The following alerts are firing:\n\n"
+        + "\n".join(alert_summary)
+        + "\n\nInvestigate these alerts. Query relevant data sources to determine "
+        "the root cause and suggest remediation steps."
+    )
+
+    client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
+    messages = [{"role": "user", "content": user_message}]
+    total_input_tokens = 0
+    total_output_tokens = 0
+    final_text = ""
+
+    async with httpx.AsyncClient() as http:
+        for _iteration in range(settings.max_iterations):
+            response = client.messages.create(
+                model=settings.model,
+                max_tokens=settings.max_tokens,
+                system=system_prompt,
+                tools=TOOLS,
+                messages=messages,
+            )
+            total_input_tokens += response.usage.input_tokens
+            total_output_tokens += response.usage.output_tokens
+
+            text_parts = []
+            tool_uses = []
+            for block in response.content:
+                if block.type == "text":
+                    text_parts.append(block.text)
+                elif block.type == "tool_use":
+                    tool_uses.append(block)
+
+            if text_parts:
+                final_text = "\n".join(text_parts)
+
+            if response.stop_reason == "end_of_turn" or not tool_uses:
+                break
+
+            messages.append({"role": "assistant", "content": response.content})
+            tool_results = []
+            for tool_use in tool_uses:
+                tool_start = time.monotonic()
+                result = await execute_tool(
+                    tool_use.name, tool_use.input, http, settings
+                )
+                tool_duration = time.monotonic() - tool_start
+                if len(result) > 4000:
+                    result = result[:4000] + "\n... (truncated)"
+                tool_transcript.append(
+                    {
+                        "tool": tool_use.name,
+                        "input": tool_use.input,
+                        "output": result,
+                        "duration_s": round(tool_duration, 2),
+                    }
+                )
+                tool_results.append(
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": tool_use.id,
+                        "content": result,
+                    }
+                )
+            messages.append({"role": "user", "content": tool_results})
+
+    total_duration = time.monotonic() - start_time
+
+    incident_file = incident_store.save(
+        incident_id=incident_id,
+        alert_payload=alert_payload,
+        tool_transcript=tool_transcript,
+        diagnosis=final_text,
+        model=settings.model,
+        tokens={"input": total_input_tokens, "output": total_output_tokens},
+        duration_s=total_duration,
+    )
+    log.info("Incident saved to %s", incident_file)
+
+    alertnames = sorted(
+        {a.get("labels", {}).get("alertname", "unknown") for a in alerts}
+    )
+    alertname = "+".join(alertnames) if alertnames else "unknown"
+    await notifier.send(alertname, final_text, incident_id)

--- a/alert_triage/notifications.py
+++ b/alert_triage/notifications.py
@@ -1,0 +1,45 @@
+"""Notification backends for sending investigation results."""
+
+import logging
+from datetime import datetime, timezone
+from typing import Protocol
+
+import httpx
+
+log = logging.getLogger("alert-triage")
+
+
+class Notifier(Protocol):
+    async def send(self, alertname: str, analysis: str, incident_id: str) -> None: ...
+
+
+class DiscordNotifier:
+    def __init__(self, webhook_url: str) -> None:
+        self.webhook_url = webhook_url
+
+    async def send(self, alertname: str, analysis: str, incident_id: str) -> None:
+        if len(analysis) > 4000:
+            analysis = analysis[:3997] + "..."
+
+        embed = {
+            "title": f"Alert Triage: {alertname}",
+            "description": analysis,
+            "color": 0x9B59B6,
+            "footer": {"text": f"Incident: {incident_id}"},
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+
+        async with httpx.AsyncClient() as http:
+            try:
+                resp = await http.post(
+                    self.webhook_url, json={"embeds": [embed]}, timeout=10.0
+                )
+                resp.raise_for_status()
+                log.info("Discord message posted for %s", alertname)
+            except Exception as e:
+                log.error("Failed to post to Discord: %s", e)
+
+
+class NullNotifier:
+    async def send(self, alertname: str, analysis: str, incident_id: str) -> None:
+        log.info("Notification suppressed (no notifier configured) for %s", alertname)

--- a/alert_triage/tools.py
+++ b/alert_triage/tools.py
@@ -1,0 +1,195 @@
+"""Tool definitions and execution for alert investigation."""
+
+import json
+import time
+
+import httpx
+
+from .config import Settings
+
+TOOLS = [
+    {
+        "name": "query_loki",
+        "description": (
+            "Query container logs via Loki's LogQL API. "
+            'Use LogQL syntax, e.g. {container="sonarr"} for all sonarr logs, '
+            'or {container="sonarr"} |= "error" to filter. '
+            "Returns up to `limit` log lines from the last `lookback` period."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": 'LogQL query, e.g. {container="sonarr"} |= "error"',
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max log lines to return (default 50)",
+                    "default": 50,
+                },
+                "lookback": {
+                    "type": "string",
+                    "description": "Time range to search, e.g. '1h', '30m', '6h' (default '1h')",
+                    "default": "1h",
+                },
+            },
+            "required": ["query"],
+        },
+    },
+    {
+        "name": "query_prometheus",
+        "description": (
+            "Query Prometheus metrics via PromQL. Supports instant queries. "
+            "Use for checking current metric values, e.g. "
+            'up{job="blackbox"}, container_memory_usage_bytes, node_cpu_seconds_total.'
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": 'PromQL query, e.g. up{job="blackbox"}',
+                }
+            },
+            "required": ["query"],
+        },
+    },
+    {
+        "name": "get_docker_containers",
+        "description": (
+            "List Docker containers with their status, health, and resource usage. "
+            "Can filter by container name. Returns container ID, name, state, status, "
+            "and image for each container."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "name_filter": {
+                    "type": "string",
+                    "description": "Filter containers by name (substring match). Leave empty for all containers.",
+                }
+            },
+            "required": [],
+        },
+    },
+    {
+        "name": "get_alert_details",
+        "description": (
+            "Get current active alerts from Alertmanager. "
+            "Returns all firing and pending alerts with their labels, annotations, "
+            "and timing information."
+        ),
+        "input_schema": {"type": "object", "properties": {}, "required": []},
+    },
+]
+
+
+async def execute_tool(
+    name: str, input_data: dict, http: httpx.AsyncClient, settings: Settings
+) -> str:
+    """Execute a tool call and return the result as a string."""
+    try:
+        if name == "query_loki":
+            query = input_data["query"]
+            limit = input_data.get("limit", 50)
+            lookback = input_data.get("lookback", "1h")
+            unit = lookback[-1]
+            value = int(lookback[:-1])
+            seconds = value * {"s": 1, "m": 60, "h": 3600, "d": 86400}.get(unit, 3600)
+            now_ns = int(time.time() * 1e9)
+            start_ns = now_ns - (seconds * int(1e9))
+            resp = await http.get(
+                f"{settings.loki_url}/loki/api/v1/query_range",
+                params={
+                    "query": query,
+                    "start": str(start_ns),
+                    "end": str(now_ns),
+                    "limit": str(limit),
+                },
+                timeout=15.0,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            results = data.get("data", {}).get("result", [])
+            lines = []
+            for stream in results:
+                labels = stream.get("stream", {})
+                label_str = ", ".join(
+                    f"{k}={v}" for k, v in labels.items() if k == "container"
+                )
+                for _ts, line in stream.get("values", []):
+                    lines.append(f"[{label_str}] {line}")
+            if not lines:
+                return "No log lines found for this query."
+            return "\n".join(lines[:limit])
+
+        elif name == "query_prometheus":
+            query = input_data["query"]
+            resp = await http.get(
+                f"{settings.prometheus_url}/api/v1/query",
+                params={"query": query},
+                timeout=15.0,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            results = data.get("data", {}).get("result", [])
+            if not results:
+                return "No results for this query."
+            lines = []
+            for r in results:
+                metric = r.get("metric", {})
+                val = r.get("value", [None, None])
+                metric_str = json.dumps(metric, separators=(",", ":"))
+                lines.append(f"{metric_str} => {val[1]}")
+            return "\n".join(lines)
+
+        elif name == "get_docker_containers":
+            name_filter = input_data.get("name_filter", "")
+            params = {}
+            if name_filter:
+                params["filters"] = json.dumps({"name": [name_filter]})
+            transport = httpx.AsyncHTTPTransport(uds=settings.docker_socket)
+            async with httpx.AsyncClient(
+                transport=transport, base_url="http://docker"
+            ) as docker:
+                resp = await docker.get("/containers/json", params=params, timeout=10.0)
+                resp.raise_for_status()
+                containers = resp.json()
+            if not containers:
+                return "No containers found matching the filter."
+            lines = []
+            for c in containers:
+                names = ", ".join(n.lstrip("/") for n in c.get("Names", []))
+                state = c.get("State", "unknown")
+                status = c.get("Status", "unknown")
+                image = c.get("Image", "unknown")
+                lines.append(f"{names}: state={state}, status={status}, image={image}")
+            return "\n".join(lines)
+
+        elif name == "get_alert_details":
+            resp = await http.get(
+                f"{settings.alertmanager_url}/api/v2/alerts", timeout=10.0
+            )
+            resp.raise_for_status()
+            alerts = resp.json()
+            if not alerts:
+                return "No active alerts in Alertmanager."
+            lines = []
+            for a in alerts:
+                labels = a.get("labels", {})
+                annotations = a.get("annotations", {})
+                status = a.get("status", {}).get("state", "unknown")
+                starts_at = a.get("startsAt", "unknown")
+                lines.append(
+                    f"[{status}] {labels.get('alertname', '?')} — "
+                    f"{annotations.get('summary', 'no summary')} "
+                    f"(since {starts_at})"
+                )
+            return "\n".join(lines)
+
+        else:
+            return f"Unknown tool: {name}"
+
+    except Exception as e:
+        return f"Error executing {name}: {e}"

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,0 +1,29 @@
+---
+services:
+  alert-triage:
+    image: ghcr.io/tylerwolf/alert-triage:0.1.0
+    container_name: alert-triage
+    restart: unless-stopped
+    env_file: alert-triage.env
+    environment:
+      # Point to your monitoring stack (defaults assume Docker Compose service names)
+      - ALERT_TRIAGE_LOKI_URL=http://loki:3100
+      - ALERT_TRIAGE_PROMETHEUS_URL=http://prometheus:9090
+      - ALERT_TRIAGE_ALERTMANAGER_URL=http://alertmanager:9093
+      # Mount a custom system prompt describing your environment (optional)
+      - ALERT_TRIAGE_SYSTEM_PROMPT_FILE=/config/system-prompt.md
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - alert_triage_data:/data
+      # Mount your environment-specific system prompt
+      - ./system-prompt.md:/config/system-prompt.md:ro
+    ports:
+      - "8099:8099"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8099/health')"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+volumes:
+  alert_triage_data:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "alert-triage"
+version = "0.1.0"
+description = "AI-powered alert diagnosis for Docker Compose stacks"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.12"
+dependencies = [
+    "anthropic",
+    "fastapi",
+    "uvicorn[standard]",
+    "httpx",
+    "pydantic-settings",
+]
+
+[project.urls]
+Repository = "https://github.com/tylerwolf/alert-triage"

--- a/system-prompt.example.md
+++ b/system-prompt.example.md
@@ -1,0 +1,22 @@
+## Environment
+
+Describe your infrastructure here so the AI diagnostician has context about your setup.
+
+Services running (Docker):
+- Traefik (reverse proxy, port 443/80)
+- Your services here...
+- Prometheus (port 9090), Grafana (port 3000), Alertmanager (port 9093)
+- Loki (port 3100), Promtail, Node Exporter, cAdvisor, Blackbox Exporter
+
+Network details:
+- Server IP: 192.168.x.x
+- NAS mounts: /mnt/nas/data (nas-hostname, 192.168.x.x)
+
+## Alert Types
+
+Describe the alerts configured in your Prometheus rules:
+
+- ServiceDown: Blackbox probe failing. Check if the container is running, then check its logs.
+- HighCPU: CPU above 85% for 5+ min. Identify top consumers via container metrics.
+- HighMemory: Memory above 90% for 5+ min. Identify top consumers.
+- Add your custom alerts here...


### PR DESCRIPTION
## Summary
- FastAPI app that receives Alertmanager webhooks and uses Claude tool-calling to investigate alerts via Loki, Prometheus, Docker, and Alertmanager APIs
- All config via `ALERT_TRIAGE_*` env vars with Pydantic Settings (sensible defaults for Docker Compose stacks)
- Webhook coalescing (45s window), dedup (30min), concurrency cap (3), and startup reconciliation
- Notifier protocol with Discord implementation; incidents stored as JSON files with REST API
- CI workflow (ruff lint + format check) and Release workflow (multi-arch Docker image to GHCR on tag push)
- Example docker-compose and system prompt template for users to customize

## Files
| File | Purpose |
|---|---|
| `alert_triage/config.py` | Pydantic Settings + base system prompt |
| `alert_triage/tools.py` | Tool definitions + execute_tool |
| `alert_triage/investigation.py` | Claude investigation loop |
| `alert_triage/notifications.py` | Notifier protocol + Discord/Null |
| `alert_triage/incidents.py` | IncidentStore (JSON file storage) |
| `alert_triage/app.py` | FastAPI routes, coalescing, dedup, reconciliation |
| `Dockerfile` | Python 3.12 slim image |
| `.github/workflows/ci.yml` | Ruff lint on push/PR |
| `.github/workflows/release.yml` | Build + push to GHCR on `v*` tag |

## Test plan
- [ ] Review code for correctness and security
- [ ] Verify Docker image builds (`docker build -t alert-triage:test .`)
- [ ] Verify ruff passes (`ruff check . && ruff format --check .`)
- [ ] After merge: tag `v0.1.0`, confirm GHCR image publishes
- [ ] Deploy with homelab compose changes, trigger test alert

🤖 Generated with [Claude Code](https://claude.com/claude-code)